### PR TITLE
Add missing attribute name

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,7 @@
 name: Build and deploy to crates.io
 on:
   push:
+    branches: [main]
     paths:
     - 'Cargo.toml'
 jobs:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "android-manifest"
-version = "0.1.5"
+version = "0.1.7"
 authors = ["DodoRare Team <dodonotrare@gmail.com>"]
 description = "Android Manifest serializer and deserializer for Rust"
 repository = "https://github.com/dodorare/android-manifest-rs"
@@ -9,10 +9,10 @@ edition = "2018"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-serde_plain = "0.3"
-yaserde = "0.7.0"
-yaserde_derive = "0.7.0"
-xml-rs = "0.8.3"
+serde_plain = "1.0"
+yaserde = "0.8"
+yaserde_derive = "0.8"
+xml-rs = "0.8.4"
 thiserror = "1.0"
 displaydoc = "0.2"
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "android-manifest"
-version = "0.1.7"
+version = "0.1.8"
 authors = ["DodoRare Team <dodonotrare@gmail.com>"]
 description = "Android Manifest serializer and deserializer for Rust"
 repository = "https://github.com/dodorare/android-manifest-rs"

--- a/src/action.rs
+++ b/src/action.rs
@@ -21,7 +21,9 @@ use serde::{Deserialize, Serialize};
 /// [`<intent-filter>`]: crate::IntentFilter
 /// [`Intent`]: https://developer.android.com/reference/android/content/Intent
 /// [`Intents and Intent Filters`]: https://developer.android.com/guide/components/intents-filters
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
+#[derive(
+    Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone,
+)]
 pub struct Action {
     /// The name of the action. Some standard actions are defined in the [`Intent`] class
     /// as `ACTION_string` constants. To assign one of these actions to this

--- a/src/action.rs
+++ b/src/action.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 /// [`<intent-filter>`]: crate::IntentFilter
 /// [`Intent`]: https://developer.android.com/reference/android/content/Intent
 /// [`Intents and Intent Filters`]: https://developer.android.com/guide/components/intents-filters
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
 pub struct Action {
     /// The name of the action. Some standard actions are defined in the [`Intent`] class
     /// as `ACTION_string` constants. To assign one of these actions to this

--- a/src/activity.rs
+++ b/src/activity.rs
@@ -828,7 +828,7 @@ impl Activity {
 
 /// Requests the activity to be displayed in wide color gamut mode on compatible
 /// devices.
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum ColorMode {
     /// Indicating that the activity should use a high dynamic range if the presentation
@@ -850,7 +850,7 @@ impl Default for ColorMode {
 }
 
 /// Lists configuration changes that the `activity` will handle itself.
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum ConfigChanges {
     /// The display density has changed — the user might have specified a different
@@ -936,7 +936,7 @@ impl Default for ConfigChanges {
 
 /// Four values which produce the following effects when the user opens a document with
 /// the application
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum DocumentLaunchMode {
     /// The system searches for a task whose base intent's `ComponentName` and data URI
@@ -1054,7 +1054,7 @@ impl Default for DocumentLaunchMode {
 /// [`navigate up`]: https://developer.android.com/guide/navigation
 /// [`FLAG_ACTIVITY_CLEAR_TOP`]: https://developer.android.com/reference/android/content/Intent#FLAG_ACTIVITY_CLEAR_TOP
 /// [`Tasks and Back Stack`]: https://developer.android.com/guide/components/activities/tasks-and-back-stack
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum LaunchMode {
     /// Default. The system always creates a new instance of the activity in the target
@@ -1110,7 +1110,7 @@ impl Default for LaunchMode {
 /// The value can be any one of the following [`R.attr.lockTaskMode`] string values:
 ///
 /// [`R.attr.lockTaskMode`]: https://developer.android.com/reference/android/R.attr#lockTaskMode
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum LockTaskMode {
     /// `Default value`. This is the default value. Tasks don't launch into lock task mode
@@ -1160,7 +1160,7 @@ impl Default for LockTaskMode {
 
 /// Defines how an instance of an activity is preserved within a containing task
 /// across device restarts.
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum PersistableMode {
     /// `Default value`. When the system restarts, the activity task is preserved, but
@@ -1220,7 +1220,7 @@ impl Default for PersistableMode {
 }
 
 /// The orientation of the activity's display on the device.
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum ScreenOrientation {
     /// `The default value`. The system chooses the orientation. The policy it uses, and
@@ -1320,7 +1320,7 @@ impl Default for ScreenOrientation {
 
 /// How the main window of the activity interacts with the window containing the on-screen
 /// soft keyboard.
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum WindowSoftInputMode {
     /// The state of the soft keyboard (whether it is hidden or visible) is not

--- a/src/activity_alias.rs
+++ b/src/activity_alias.rs
@@ -50,7 +50,7 @@ use serde::{Deserialize, Serialize};
 /// [`<activity>`]: crate::Activity
 /// [`android.intent.action.MAIN`]: https://developer.android.com/reference/android/content/Intent#ACTION_MAIN
 /// [`android.intent.category.LAUNCHER`]: https://developer.android.com/reference/android/content/Intent#CATEGORY_LAUNCHER
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
 pub struct ActivityAlias {
     /// Whether or not the target activity can be instantiated by the system through this
     /// alias — "`true`" if it can be, and "`false`" if not. The default value is

--- a/src/activity_alias.rs
+++ b/src/activity_alias.rs
@@ -50,7 +50,9 @@ use serde::{Deserialize, Serialize};
 /// [`<activity>`]: crate::Activity
 /// [`android.intent.action.MAIN`]: https://developer.android.com/reference/android/content/Intent#ACTION_MAIN
 /// [`android.intent.category.LAUNCHER`]: https://developer.android.com/reference/android/content/Intent#CATEGORY_LAUNCHER
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
+#[derive(
+    Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone,
+)]
 pub struct ActivityAlias {
     /// Whether or not the target activity can be instantiated by the system through this
     /// alias — "`true`" if it can be, and "`false`" if not. The default value is

--- a/src/application.rs
+++ b/src/application.rs
@@ -711,7 +711,7 @@ pub struct Application {
 ///
 /// [`use-after-free`]: https://cwe.mitre.org/data/definitions/416.html
 /// [`heap-buffer-overflow`]: https://cwe.mitre.org/data/definitions/122.html
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum GwpAsanMode {
     /// Always disabled: This setting completely disables GWP-ASan in your app and is the

--- a/src/attribute_list.rs
+++ b/src/attribute_list.rs
@@ -12,7 +12,7 @@ pub trait Delimiter {
     fn delimiter_symbol() -> &'static str;
 }
 
-#[derive(Debug, PartialEq, Default, Clone)]
+#[derive(Debug, PartialEq, Eq, Default, Clone)]
 pub struct Semicolon;
 
 impl Delimiter for Semicolon {
@@ -21,7 +21,7 @@ impl Delimiter for Semicolon {
     }
 }
 
-#[derive(Debug, PartialEq, Default, Clone)]
+#[derive(Debug, PartialEq, Eq, Default, Clone)]
 pub struct VerticalBar;
 
 impl Delimiter for VerticalBar {
@@ -30,7 +30,7 @@ impl Delimiter for VerticalBar {
     }
 }
 
-#[derive(Debug, PartialEq, Default, Clone)]
+#[derive(Debug, PartialEq, Eq, Default, Clone)]
 pub struct AttributeList<D: Delimiter, T: Serialize + DeserializeOwned> {
     vec: Vec<T>,
     phantom: PhantomData<D>,

--- a/src/category.rs
+++ b/src/category.rs
@@ -18,7 +18,9 @@ use serde::{Deserialize, Serialize};
 ///
 /// [`Intents and Intent Filters`]: https://developer.android.com/guide/components/intents-filters
 /// [`<intent-filter>`]: crate::IntentFilter
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
+#[derive(
+    Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone,
+)]
 pub struct Category {
     /// The name of the category. Standard categories are defined in the [`Intent`]
     /// class as CATEGORY_name constants. The name assigned here can be derived

--- a/src/category.rs
+++ b/src/category.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// [`Intents and Intent Filters`]: https://developer.android.com/guide/components/intents-filters
 /// [`<intent-filter>`]: crate::IntentFilter
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
 pub struct Category {
     /// The name of the category. Standard categories are defined in the [`Intent`]
     /// class as CATEGORY_name constants. The name assigned here can be derived

--- a/src/compatible_screens.rs
+++ b/src/compatible_screens.rs
@@ -59,7 +59,7 @@ use serde::{Deserialize, Serialize};
 /// [`<supports-screens>`]: crate::SupportsScreens
 /// [`Filters on Google Play`]: https://developer.android.com/google/play/filters
 /// [`<manifest>`]: crate::AndroidManifest
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Clone)]
 pub struct CompatibleScreens {
     pub screen: Vec<Screen>,
 }
@@ -109,7 +109,7 @@ pub struct CompatibleScreens {
 /// [`<compatible-screens>`]
 ///
 /// [`<compatible-screens>`]: crate::CompatibleScreens
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Clone)]
 pub struct Screen {
     /// `Required`. Specifies the screen size for this screen configuration.
     ///
@@ -143,7 +143,7 @@ pub struct Screen {
 /// Android runs on a variety of devices that have different screen sizes and pixel
 /// densities. The system performs basic scaling and resizing to adapt your user interface
 /// to different screens.
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum ScreenSize {
     /// Screens that are of similar size to a low-density QVGA screen. The minimum layout

--- a/src/data.rs
+++ b/src/data.rs
@@ -68,7 +68,7 @@ use serde::{Deserialize, Serialize};
 /// [`<intent-filter>`]: crate::IntentFilter
 /// [`Intents and Intent Filters`]: https://developer.android.com/guide/components/intents-filters
 /// [`Intent Filters`]: https://developer.android.com/guide/topics/manifest/manifest-intro#ifs
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
 pub struct Data {
     /// The scheme part of a URI. This is the minimal essential attribute for specifying a
     /// URI; at least one scheme attribute must be set for the filter, or none of the

--- a/src/data.rs
+++ b/src/data.rs
@@ -68,7 +68,9 @@ use serde::{Deserialize, Serialize};
 /// [`<intent-filter>`]: crate::IntentFilter
 /// [`Intents and Intent Filters`]: https://developer.android.com/guide/components/intents-filters
 /// [`Intent Filters`]: https://developer.android.com/guide/topics/manifest/manifest-intro#ifs
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
+#[derive(
+    Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone,
+)]
 pub struct Data {
     /// The scheme part of a URI. This is the minimal essential attribute for specifying a
     /// URI; at least one scheme attribute must be set for the filter, or none of the

--- a/src/grant_uri_permission.rs
+++ b/src/grant_uri_permission.rs
@@ -33,7 +33,7 @@ use serde::{Deserialize, Serialize};
 /// [`grantUriPermissions`]: crate::Provider#structfield.grant_uri_permissions
 /// [`<intent-filter>`]: crate::IntentFilter
 /// [`<provider>`]: crate::Provider
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
 pub struct GrantUriPermission {
     /// A path identifying the data subset or subsets that permission can be  granted for.
     /// The path attribute specifies a complete path; permission can be granted only

--- a/src/grant_uri_permission.rs
+++ b/src/grant_uri_permission.rs
@@ -33,7 +33,9 @@ use serde::{Deserialize, Serialize};
 /// [`grantUriPermissions`]: crate::Provider#structfield.grant_uri_permissions
 /// [`<intent-filter>`]: crate::IntentFilter
 /// [`<provider>`]: crate::Provider
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
+#[derive(
+    Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone,
+)]
 pub struct GrantUriPermission {
     /// A path identifying the data subset or subsets that permission can be  granted for.
     /// The path attribute specifies a complete path; permission can be granted only

--- a/src/instrumentation.rs
+++ b/src/instrumentation.rs
@@ -26,7 +26,9 @@ use serde::{Deserialize, Serialize};
 ///
 /// [`Instrumentation`]: https://developer.android.com/reference/android/app/Instrumentation
 /// [`<manifest>`]: crate::AndroidManifest
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
+#[derive(
+    Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone,
+)]
 pub struct Instrumentation {
     /// Whether or not the Instrumentation class should run as a functional test —
     /// `"true"` if it should, and `"false"` if not. The default value is `"false"`.

--- a/src/instrumentation.rs
+++ b/src/instrumentation.rs
@@ -26,7 +26,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// [`Instrumentation`]: https://developer.android.com/reference/android/app/Instrumentation
 /// [`<manifest>`]: crate::AndroidManifest
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
 pub struct Instrumentation {
     /// Whether or not the Instrumentation class should run as a functional test —
     /// `"true"` if it should, and `"false"` if not. The default value is `"false"`.

--- a/src/intent_filter.rs
+++ b/src/intent_filter.rs
@@ -53,7 +53,7 @@ use serde::{Deserialize, Serialize};
 /// [`<action>`]: crate::Action
 /// [`<category>`]: crate::Category
 /// [`<data>`]: crate::Data
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
 pub struct IntentFilter {
     /// An icon that represents the parent activity, service, or broadcast receiver when
     /// that component is presented to the user as having the capability described by

--- a/src/intent_filter.rs
+++ b/src/intent_filter.rs
@@ -53,7 +53,9 @@ use serde::{Deserialize, Serialize};
 /// [`<action>`]: crate::Action
 /// [`<category>`]: crate::Category
 /// [`<data>`]: crate::Data
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
+#[derive(
+    Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone,
+)]
 pub struct IntentFilter {
     /// An icon that represents the parent activity, service, or broadcast receiver when
     /// that component is presented to the user as having the capability described by

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 /// * [`<activity>`]
 ///
 /// [`<activity>`]: crate::Activity
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
 pub struct Layout {
     /// Default width of the activity when launched in freeform mode.
     #[yaserde(attribute, prefix = "android", rename = "defaultWidth")]
@@ -67,7 +67,7 @@ pub struct Layout {
 
 /// Standard constants and tools for placing an object within a potentially
 /// larger container.
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum Gravity {
     /// Raw bit controlling whether the right/bottom edge is clipped to its

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -9,7 +9,9 @@ use serde::{Deserialize, Serialize};
 /// * [`<activity>`]
 ///
 /// [`<activity>`]: crate::Activity
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
+#[derive(
+    Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone,
+)]
 pub struct Layout {
     /// Default width of the activity when launched in freeform mode.
     #[yaserde(attribute, prefix = "android", rename = "defaultWidth")]

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -266,7 +266,7 @@ pub struct AndroidManifest {
 }
 
 /// The default install location for the app.
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum InstallLocation {
     /// The app may be installed on the external storage, but the system will install the

--- a/src/meta_data.rs
+++ b/src/meta_data.rs
@@ -59,7 +59,9 @@ use serde::{Deserialize, Serialize};
 /// [`<service>`]: crate::Service
 /// [`<receiver>`]: crate::Receiver
 /// [`<provider>`]: crate::Provider
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
+#[derive(
+    Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone,
+)]
 pub struct MetaData {
     /// A unique name for the item. To ensure that the name is unique, use a Java-style
     /// naming convention — for example, `"com.example.project.activity.fred"`.

--- a/src/meta_data.rs
+++ b/src/meta_data.rs
@@ -59,7 +59,7 @@ use serde::{Deserialize, Serialize};
 /// [`<service>`]: crate::Service
 /// [`<receiver>`]: crate::Receiver
 /// [`<provider>`]: crate::Provider
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
 pub struct MetaData {
     /// A unique name for the item. To ensure that the name is unique, use a Java-style
     /// naming convention — for example, `"com.example.project.activity.fred"`.

--- a/src/path_permission.rs
+++ b/src/path_permission.rs
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 /// API Level 4
 ///
 /// [`<provider>`]: crate::Provider
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
 pub struct PathPermission {
     /// A complete URI path for a subset of content provider data. Permission can be
     /// granted only to the particular data identified by this path. When used to

--- a/src/path_permission.rs
+++ b/src/path_permission.rs
@@ -23,7 +23,9 @@ use serde::{Deserialize, Serialize};
 /// API Level 4
 ///
 /// [`<provider>`]: crate::Provider
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
+#[derive(
+    Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone,
+)]
 pub struct PathPermission {
     /// A complete URI path for a subset of content provider data. Permission can be
     /// granted only to the particular data identified by this path. When used to

--- a/src/permission.rs
+++ b/src/permission.rs
@@ -29,7 +29,9 @@ use serde::{Deserialize, Serialize};
 /// [`<manifest>`]: crate::AndroidManifest
 /// [`Permissions`]: https://developer.android.com/guide/topics/manifest/manifest-intro#perms
 /// [`Security and Permissions`]: https://developer.android.com/training/articles/security-tips
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
+#[derive(
+    Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone,
+)]
 pub struct Permission {
     /// A user-readable description of the permission, longer and more informative than
     /// the label. It may be displayed to explain the permission to the user — for

--- a/src/permission.rs
+++ b/src/permission.rs
@@ -29,7 +29,7 @@ use serde::{Deserialize, Serialize};
 /// [`<manifest>`]: crate::AndroidManifest
 /// [`Permissions`]: https://developer.android.com/guide/topics/manifest/manifest-intro#perms
 /// [`Security and Permissions`]: https://developer.android.com/training/articles/security-tips
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
 pub struct Permission {
     /// A user-readable description of the permission, longer and more informative than
     /// the label. It may be displayed to explain the permission to the user — for
@@ -91,7 +91,7 @@ pub struct Permission {
 /// see [`protectionLevel`].
 ///
 /// [`protectionLevel`]: https://developer.android.com/reference/android/R.attr#protectionLevel
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum ProtectionLevel {
     /// The default value. A lower-risk permission that gives requesting applications

--- a/src/permission_group.rs
+++ b/src/permission_group.rs
@@ -29,7 +29,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// [`<manifest>`]: crate::AndroidManifest
 /// [`<permission>`]: crate::Permission
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
 pub struct PermissionGroup {
     /// User-readable text that describes the group. The text should be longer and more
     /// explanatory than the label. This attribute must be set as a reference to a

--- a/src/permission_group.rs
+++ b/src/permission_group.rs
@@ -29,7 +29,9 @@ use serde::{Deserialize, Serialize};
 ///
 /// [`<manifest>`]: crate::AndroidManifest
 /// [`<permission>`]: crate::Permission
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
+#[derive(
+    Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone,
+)]
 pub struct PermissionGroup {
     /// User-readable text that describes the group. The text should be longer and more
     /// explanatory than the label. This attribute must be set as a reference to a

--- a/src/permission_tree.rs
+++ b/src/permission_tree.rs
@@ -34,7 +34,7 @@ use serde::{Deserialize, Serialize};
 /// [`PackageManager.addPermission()`]: https://developer.android.com/reference/android/content/pm/PackageManager#addPermission(android.content.pm.PermissionInfo)
 /// [`<permission>`]: crate::Permission
 /// [`<manifest>`]: crate::AndroidManifest
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
 pub struct PermissionTree {
     /// An icon representing all the permissions in the tree. This attribute must be set
     /// as a reference to a drawable resource containing the image definition.

--- a/src/permission_tree.rs
+++ b/src/permission_tree.rs
@@ -34,7 +34,9 @@ use serde::{Deserialize, Serialize};
 /// [`PackageManager.addPermission()`]: https://developer.android.com/reference/android/content/pm/PackageManager#addPermission(android.content.pm.PermissionInfo)
 /// [`<permission>`]: crate::Permission
 /// [`<manifest>`]: crate::AndroidManifest
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
+#[derive(
+    Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone,
+)]
 pub struct PermissionTree {
     /// An icon representing all the permissions in the tree. This attribute must be set
     /// as a reference to a drawable resource containing the image definition.

--- a/src/profileable.rs
+++ b/src/profileable.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 /// API Level 29
 ///
 /// [`<application>`]: crate::Application
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
 pub struct Profileable {
     /// Specifies whether the user of the device can profile this application
     /// through local debugging tools. These include

--- a/src/profileable.rs
+++ b/src/profileable.rs
@@ -16,7 +16,9 @@ use serde::{Deserialize, Serialize};
 /// API Level 29
 ///
 /// [`<application>`]: crate::Application
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
+#[derive(
+    Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone,
+)]
 pub struct Profileable {
     /// Specifies whether the user of the device can profile this application
     /// through local debugging tools. These include

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -81,7 +81,9 @@ use serde::{Deserialize, Serialize};
 /// [`<grant-uri-permission>`]: crate::GrantUriPermission
 /// [`<intent-filter>`]: crate::IntentFilter
 /// [`<path-permission>`]: crate::PathPermission
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
+#[derive(
+    Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone,
+)]
 #[serde(rename = "provider")]
 pub struct Provider {
     /// A list of one or more URI authorities that identify data offered by the content

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -81,7 +81,7 @@ use serde::{Deserialize, Serialize};
 /// [`<grant-uri-permission>`]: crate::GrantUriPermission
 /// [`<intent-filter>`]: crate::IntentFilter
 /// [`<path-permission>`]: crate::PathPermission
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
 #[serde(rename = "provider")]
 pub struct Provider {
     /// A list of one or more URI authorities that identify data offered by the content

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -164,6 +164,18 @@ pub struct QueriesProvider {
     )]
     #[serde(skip_serializing_if = "AttributeList::is_empty")]
     pub authorities: AttributeList<Semicolon, String>,
+    /// The name of the class that implements the content provider, a subclass of
+    /// [`ContentProvider`]. This should be a fully qualified class name (such
+    /// as, `"com.example.project.TransportationProvider"`). However, as a
+    /// shorthand, if the first character of the name is a period, it is
+    /// appended to the package name specified in the [`<manifest>`] element.
+    ///
+    /// There is no default. The name must be specified.
+    ///
+    /// [`ContentProvider`]: https://developer.android.com/reference/android/content/ContentProvider
+    /// [`<manifest>`]: crate::AndroidManifest
+    #[yaserde(attribute, prefix = "android")]
+    pub name: String,
 }
 
 impl QueriesProvider {

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -36,7 +36,7 @@ use serde::{Deserialize, Serialize};
 /// [`<manifest>`]: crate::AndroidManifest
 /// [`package visibility filtering`]: https://developer.android.com/training/package-visibility
 /// [`visible automatically`]: https://developer.android.com/training/package-visibility/automatic
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Clone)]
 pub struct Queries {
     /// Specifies a single app that your app intends to access. This other app might
     /// integrate with your app, or your app might use services that the other app
@@ -60,7 +60,7 @@ pub struct Queries {
 
 /// Specifies a single app that your app intends to access. This other app might integrate
 /// with your app, or your app might use services that the other app provides.
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Clone)]
 pub struct Package {
     /// `Required`. Specifies the package name of the other app.
     #[yaserde(attribute, prefix = "android")]
@@ -79,7 +79,7 @@ pub struct Package {
 /// [`<intent-filter>`]: crate::IntentFilter
 /// [`intent filter signature`]: https://developer.android.com/training/basics/intents/filters
 /// [`declaring package visibility needs`]: https://developer.android.com/training/package-visibility/declaring#intent-filter-signature
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
 pub struct Intent {
     pub action: Action,
     pub data: Vec<Data>,
@@ -145,7 +145,7 @@ pub struct Intent {
 /// [`Content Providers`]: https://developer.android.com/guide/topics/providers/content-providers
 /// [`<queries>`]: crate::Queries
 /// [`Preparing your Gradle build for package visibility in Android 11`]: https://android-developers.googleblog.com/2020/07/preparing-your-build-for-package-visibility-in-android-11.html
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
 #[serde(rename = "provider")]
 pub struct QueriesProvider {
     /// A list of one or more URI authorities that identify data offered by the content

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -79,7 +79,9 @@ pub struct Package {
 /// [`<intent-filter>`]: crate::IntentFilter
 /// [`intent filter signature`]: https://developer.android.com/training/basics/intents/filters
 /// [`declaring package visibility needs`]: https://developer.android.com/training/package-visibility/declaring#intent-filter-signature
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
+#[derive(
+    Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone,
+)]
 pub struct Intent {
     pub action: Action,
     pub data: Vec<Data>,
@@ -145,7 +147,9 @@ pub struct Intent {
 /// [`Content Providers`]: https://developer.android.com/guide/topics/providers/content-providers
 /// [`<queries>`]: crate::Queries
 /// [`Preparing your Gradle build for package visibility in Android 11`]: https://android-developers.googleblog.com/2020/07/preparing-your-build-for-package-visibility-in-android-11.html
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
+#[derive(
+    Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone,
+)]
 #[serde(rename = "provider")]
 pub struct QueriesProvider {
     /// A list of one or more URI authorities that identify data offered by the content

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -51,7 +51,7 @@ use serde::{Deserialize, Serialize};
 /// [`<application>`]: crate::Application
 /// [`<intent-filter>`]: crate::IntentFilter
 /// [`<meta-data>`]: crate::MetaData
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
 pub struct Receiver {
     /// Whether or not the broadcast `receiver` is direct-boot aware; that is,
     /// whether or not it can run before the user unlocks the device.

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -51,7 +51,9 @@ use serde::{Deserialize, Serialize};
 /// [`<application>`]: crate::Application
 /// [`<intent-filter>`]: crate::IntentFilter
 /// [`<meta-data>`]: crate::MetaData
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
+#[derive(
+    Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone,
+)]
 pub struct Receiver {
     /// Whether or not the broadcast `receiver` is direct-boot aware; that is,
     /// whether or not it can run before the user unlocks the device.

--- a/src/resources/any.rs
+++ b/src/resources/any.rs
@@ -11,7 +11,7 @@ use std::io::{Read, Write};
 use yaserde::{YaDeserialize, YaSerialize};
 
 /// Enum used when the value can be any of available resources.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum AnyResource {
     String(Resource<StringResource>),
     Drawable(Resource<DrawableResource>),

--- a/src/resources/mipmap_or_drawable.rs
+++ b/src/resources/mipmap_or_drawable.rs
@@ -11,7 +11,7 @@ use std::io::{Read, Write};
 use yaserde::{YaDeserialize, YaSerialize};
 
 /// Enum used when the value can be string resource or just a row string.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum MipmapOrDrawableResource {
     Mipmap(Resource<MipmapResource>),
     Drawable(Resource<DrawableResource>),

--- a/src/resources/mod.rs
+++ b/src/resources/mod.rs
@@ -6,14 +6,17 @@ mod types;
 pub use any::*;
 pub use mipmap_or_drawable::*;
 pub use res_or_string::*;
+
 use serde::{
     de::{self, Visitor},
     Deserialize, Deserializer, Serialize, Serializer,
 };
-use std::fmt;
-use std::io::{Read, Write};
-use std::marker::PhantomData;
-use std::str::FromStr;
+use std::{
+    fmt,
+    io::{Read, Write},
+    marker::PhantomData,
+    str::FromStr,
+};
 pub use types::*;
 use yaserde::{YaDeserialize, YaSerialize};
 
@@ -188,7 +191,7 @@ fn parse_resource(resource: &str) -> Result<(Option<String>, String, String), St
                 .to_string(),
         );
     };
-    let first_part = split_str.get(0).unwrap();
+    let first_part = split_str.first().unwrap(); // Can be unwraped because we checked the length.
     let resource_type = &first_part[1..];
     let split_type: Vec<_> = resource_type.split(':').collect();
     let (resource_type, package) = if split_type.len() == 2 {
@@ -196,7 +199,7 @@ fn parse_resource(resource: &str) -> Result<(Option<String>, String, String), St
     } else {
         (split_type[0], None)
     };
-    let resource_name = split_str.get(1).unwrap();
+    let resource_name = split_str.get(1).unwrap(); // Can be unwraped because we checked the length.
     Ok((
         package,
         resource_type.to_string(),

--- a/src/resources/mod.rs
+++ b/src/resources/mod.rs
@@ -32,7 +32,7 @@ pub trait ResourceType: FromStr {
 }
 
 /// Generic resource type.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Resource<T: ResourceType> {
     name: String,
     package: Option<String>,

--- a/src/resources/res_or_string.rs
+++ b/src/resources/res_or_string.rs
@@ -8,7 +8,7 @@ use std::io::{Read, Write};
 use yaserde::{YaDeserialize, YaSerialize};
 
 /// Enum used when the value can be string resource or just a row string.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum StringResourceOrString {
     StringResource(Resource<StringResource>),
     String(String),

--- a/src/resources/types.rs
+++ b/src/resources/types.rs
@@ -2,7 +2,7 @@ use super::ResourceType;
 use std::str::FromStr;
 
 /// String resource type.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct StringResource;
 
 impl FromStr for StringResource {
@@ -24,7 +24,7 @@ impl ResourceType for StringResource {
 }
 
 /// Drawable resource type.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct DrawableResource;
 
 impl FromStr for DrawableResource {
@@ -46,7 +46,7 @@ impl ResourceType for DrawableResource {
 }
 
 /// Mipmap resource type.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct MipmapResource;
 
 impl FromStr for MipmapResource {
@@ -68,7 +68,7 @@ impl ResourceType for MipmapResource {
 }
 
 /// Xml resource type.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct XmlResource;
 
 impl FromStr for XmlResource {
@@ -90,7 +90,7 @@ impl ResourceType for XmlResource {
 }
 
 /// Style resource type.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct StyleResource;
 
 impl FromStr for StyleResource {

--- a/src/service.rs
+++ b/src/service.rs
@@ -53,7 +53,9 @@ use serde::{Deserialize, Serialize};
 /// [`<application>`]: crate::Application
 /// [`<intent-filter>`]: crate::IntentFilter
 /// [`<meta-data>`]: crate::MetaData
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
+#[derive(
+    Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone,
+)]
 pub struct Service {
     /// A string that describes the service to users. The label should be set as a
     /// reference to a string resource, so that it can be localized like other strings

--- a/src/service.rs
+++ b/src/service.rs
@@ -53,7 +53,7 @@ use serde::{Deserialize, Serialize};
 /// [`<application>`]: crate::Application
 /// [`<intent-filter>`]: crate::IntentFilter
 /// [`<meta-data>`]: crate::MetaData
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
 pub struct Service {
     /// A string that describes the service to users. The label should be set as a
     /// reference to a string resource, so that it can be localized like other strings
@@ -219,7 +219,7 @@ pub struct Service {
     pub meta_data: Vec<MetaData>,
 }
 
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum ForegroundServiceType {
     #[yaserde(rename = "camera")]

--- a/src/supports_gl_texture.rs
+++ b/src/supports_gl_texture.rs
@@ -57,7 +57,9 @@ use serde::{Deserialize, Serialize};
 ///
 /// [`Google Play and texture compression filtering`]: https://developer.android.com/guide/topics/manifest/supports-gl-texture-element#market-texture-filtering
 /// [`<manifest>`]: crate::AndroidManifest
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
+#[derive(
+    Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone,
+)]
 pub struct SupportsGlTexture {
     /// Specifies a single GL texture compression format supported by the application, as
     /// a descriptor string. Common descriptor values are listed in the table below.

--- a/src/supports_gl_texture.rs
+++ b/src/supports_gl_texture.rs
@@ -57,7 +57,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// [`Google Play and texture compression filtering`]: https://developer.android.com/guide/topics/manifest/supports-gl-texture-element#market-texture-filtering
 /// [`<manifest>`]: crate::AndroidManifest
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
 pub struct SupportsGlTexture {
     /// Specifies a single GL texture compression format supported by the application, as
     /// a descriptor string. Common descriptor values are listed in the table below.
@@ -86,7 +86,7 @@ pub struct SupportsGlTexture {
     pub name: Option<SupportsGlTextureName>,
 }
 
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Clone)]
 #[allow(non_camel_case_types)]
 pub enum SupportsGlTextureName {
     /// Ericsson texture compression. Specified in OpenGL ES 2.0 and available in all

--- a/src/supports_screens.rs
+++ b/src/supports_screens.rs
@@ -82,7 +82,7 @@ use serde::{Deserialize, Serialize};
 /// [`alternative layout resources`]: https://developer.android.com/guide/topics/resources/providing-resources#AlternativeResources
 /// [`screen compatibility mode`]: https://developer.android.com/guide/topics/manifest/supports-screens-element#compat-mode
 /// [`<manifest>`]: crate::AndroidManifest
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
 pub struct SupportsScreens {
     /// Indicates whether the application is resizeable for different screen sizes. This
     /// attribute is true, by default. If set false, the system will run your

--- a/src/supports_screens.rs
+++ b/src/supports_screens.rs
@@ -82,7 +82,9 @@ use serde::{Deserialize, Serialize};
 /// [`alternative layout resources`]: https://developer.android.com/guide/topics/resources/providing-resources#AlternativeResources
 /// [`screen compatibility mode`]: https://developer.android.com/guide/topics/manifest/supports-screens-element#compat-mode
 /// [`<manifest>`]: crate::AndroidManifest
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
+#[derive(
+    Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone,
+)]
 pub struct SupportsScreens {
     /// Indicates whether the application is resizeable for different screen sizes. This
     /// attribute is true, by default. If set false, the system will run your

--- a/src/ui_options.rs
+++ b/src/ui_options.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Extra options for an activity's UI.
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum UiOptions {
     /// No extra UI options. This is the default

--- a/src/uses_configuration.rs
+++ b/src/uses_configuration.rs
@@ -35,7 +35,7 @@ use serde::{Deserialize, Serialize};
 /// [`Enabling Focus Navigation`]: https://developer.android.com/guide/topics/ui/accessibility/apps#focus-nav
 /// [`<uses-feature>`]: crate::UsesFeature
 /// [`<manifest>`]: crate::AndroidManifest
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
 pub struct UsesConfiguration {
     /// Whether or not the application requires a five-way navigation control — `"true"`
     /// if it does, and `"false"` if not. A five-way control is one that can move the
@@ -77,7 +77,7 @@ pub struct UsesConfiguration {
 }
 
 /// The type of keyboard the application requires, if any at all.
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum ReqKeyboardType {
     /// The application does not require a keyboard. (A keyboard requirement is
@@ -104,7 +104,7 @@ impl Default for ReqKeyboardType {
 }
 
 /// The navigation device required by the application, if any.
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum ReqNavigation {
     /// The application does not require any type of navigation control. (The
@@ -132,7 +132,7 @@ impl Default for ReqNavigation {
 }
 
 /// The type of touch screen the application requires, if any at all.
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum ReqTouchScreen {
     /// The application doesn't require a touch screen. (The touch screen

--- a/src/uses_configuration.rs
+++ b/src/uses_configuration.rs
@@ -35,7 +35,9 @@ use serde::{Deserialize, Serialize};
 /// [`Enabling Focus Navigation`]: https://developer.android.com/guide/topics/ui/accessibility/apps#focus-nav
 /// [`<uses-feature>`]: crate::UsesFeature
 /// [`<manifest>`]: crate::AndroidManifest
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
+#[derive(
+    Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone,
+)]
 pub struct UsesConfiguration {
     /// Whether or not the application requires a five-way navigation control — `"true"`
     /// if it does, and `"false"` if not. A five-way control is one that can move the

--- a/src/uses_feature.rs
+++ b/src/uses_feature.rs
@@ -89,7 +89,9 @@ use serde::{Deserialize, Serialize};
 /// [`minSdkVersion`]: crate::UsesSdk#structfield.min_sdk_version
 /// [`Google Play and Feature-Based Filtering`]: https://developer.android.com/guide/topics/manifest/uses-feature-element#market-feature-filtering
 /// [`<manifest>`]: crate::AndroidManifest
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
+#[derive(
+    Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone,
+)]
 pub struct UsesFeature {
     /// Specifies a single hardware or software feature used by the application,
     /// as a descriptor string. Valid attribute values are listed in the

--- a/src/uses_feature.rs
+++ b/src/uses_feature.rs
@@ -89,7 +89,7 @@ use serde::{Deserialize, Serialize};
 /// [`minSdkVersion`]: crate::UsesSdk#structfield.min_sdk_version
 /// [`Google Play and Feature-Based Filtering`]: https://developer.android.com/guide/topics/manifest/uses-feature-element#market-feature-filtering
 /// [`<manifest>`]: crate::AndroidManifest
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
 pub struct UsesFeature {
     /// Specifies a single hardware or software feature used by the application,
     /// as a descriptor string. Valid attribute values are listed in the

--- a/src/uses_library.rs
+++ b/src/uses_library.rs
@@ -45,7 +45,9 @@ use serde::{Deserialize, Serialize};
 /// [`PackageManager`]: https://developer.android.com/reference/android/content/pm/PackageManager
 /// [`Google Play filters`]: https://developer.android.com/google/play/filters
 /// [`<application>`]: crate::Application
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
+#[derive(
+    Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone,
+)]
 pub struct UsesLibrary {
     /// The name of the library. The name is provided by the documentation for the package
     /// you are using. An example of this is `"android.test.runner"`, a package that

--- a/src/uses_library.rs
+++ b/src/uses_library.rs
@@ -45,7 +45,7 @@ use serde::{Deserialize, Serialize};
 /// [`PackageManager`]: https://developer.android.com/reference/android/content/pm/PackageManager
 /// [`Google Play filters`]: https://developer.android.com/google/play/filters
 /// [`<application>`]: crate::Application
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
 pub struct UsesLibrary {
     /// The name of the library. The name is provided by the documentation for the package
     /// you are using. An example of this is `"android.test.runner"`, a package that

--- a/src/uses_native_library.rs
+++ b/src/uses_native_library.rs
@@ -42,7 +42,7 @@ use serde::{Deserialize, Serialize};
 /// [`vendor-provided shared native library`]: https://source.android.com/devices/tech/config/namespaces_libraries#adding-additional-native-libraries
 /// [`PackageManager`]: https://developer.android.com/reference/android/content/pm/PackageManager
 /// [`<application>`]: crate::Application
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
 pub struct UsesNativeLibrary {
     /// The name of the library file.
     #[yaserde(attribute, prefix = "android")]

--- a/src/uses_native_library.rs
+++ b/src/uses_native_library.rs
@@ -42,7 +42,9 @@ use serde::{Deserialize, Serialize};
 /// [`vendor-provided shared native library`]: https://source.android.com/devices/tech/config/namespaces_libraries#adding-additional-native-libraries
 /// [`PackageManager`]: https://developer.android.com/reference/android/content/pm/PackageManager
 /// [`<application>`]: crate::Application
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
+#[derive(
+    Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone,
+)]
 pub struct UsesNativeLibrary {
     /// The name of the library file.
     #[yaserde(attribute, prefix = "android")]

--- a/src/uses_permission.rs
+++ b/src/uses_permission.rs
@@ -44,7 +44,9 @@ use serde::{Deserialize, Serialize};
 /// [`android.Manifest.permission`]: https://developer.android.com/reference/android/Manifest.permission
 /// [`<uses-feature>`]: https://developer.android.com/guide/topics/manifest/uses-feature-element#permissions-features
 /// [`<manifest>`]: crate::AndroidManifest
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
+#[derive(
+    Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone,
+)]
 pub struct UsesPermission {
     /// The name of the permission. It can be a permission defined by theapplication with
     /// the [`<permission>`] element, a permission defined by another application, or

--- a/src/uses_permission.rs
+++ b/src/uses_permission.rs
@@ -44,7 +44,7 @@ use serde::{Deserialize, Serialize};
 /// [`android.Manifest.permission`]: https://developer.android.com/reference/android/Manifest.permission
 /// [`<uses-feature>`]: https://developer.android.com/guide/topics/manifest/uses-feature-element#permissions-features
 /// [`<manifest>`]: crate::AndroidManifest
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
 pub struct UsesPermission {
     /// The name of the permission. It can be a permission defined by theapplication with
     /// the [`<permission>`] element, a permission defined by another application, or

--- a/src/uses_permission_sdk_23.rs
+++ b/src/uses_permission_sdk_23.rs
@@ -41,7 +41,9 @@ use serde::{Deserialize, Serialize};
 /// [`android.Manifest.permission`]: https://developer.android.com/reference/android/Manifest.permission
 /// [`<manifest>`]: crate::AndroidManifest
 /// [`<uses-permission>`]: crate::UsesPermission
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
+#[derive(
+    Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone,
+)]
 pub struct UsesPermissionSdk23 {
     /// The name of the permission. This permission can be defined by the app
     /// with the [`<permission>`] element, it can be a permission defined by another

--- a/src/uses_permission_sdk_23.rs
+++ b/src/uses_permission_sdk_23.rs
@@ -41,7 +41,7 @@ use serde::{Deserialize, Serialize};
 /// [`android.Manifest.permission`]: https://developer.android.com/reference/android/Manifest.permission
 /// [`<manifest>`]: crate::AndroidManifest
 /// [`<uses-permission>`]: crate::UsesPermission
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
 pub struct UsesPermissionSdk23 {
     /// The name of the permission. This permission can be defined by the app
     /// with the [`<permission>`] element, it can be a permission defined by another

--- a/src/uses_sdk.rs
+++ b/src/uses_sdk.rs
@@ -32,7 +32,7 @@ use serde::{Deserialize, Serialize};
 /// [`Versioning Your Applications.`]: https://developer.android.com/studio/publish/versioning
 /// [`Google Play filters`]: https://developer.android.com/google/play/filters
 /// [`<manifest>`]: crate::AndroidManifest
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
 pub struct UsesSdk {
     /// An integer designating the minimum API Level required for the application to run.
     /// The Android system will prevent the user from installing the application if

--- a/src/uses_sdk.rs
+++ b/src/uses_sdk.rs
@@ -32,7 +32,9 @@ use serde::{Deserialize, Serialize};
 /// [`Versioning Your Applications.`]: https://developer.android.com/studio/publish/versioning
 /// [`Google Play filters`]: https://developer.android.com/google/play/filters
 /// [`<manifest>`]: crate::AndroidManifest
-#[derive(Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone)]
+#[derive(
+    Debug, Deserialize, Serialize, YaSerialize, YaDeserialize, PartialEq, Eq, Default, Clone,
+)]
 pub struct UsesSdk {
     /// An integer designating the minimum API Level required for the application to run.
     /// The Android system will prevent the user from installing the application if


### PR DESCRIPTION
The `name` attribute is normally not required for a queries provider but is non-optional as a workaround for aapt throwing errors about missing `android:name` attribute. So we need it to build APK but this will be made optional if/when we build AAB with aapt2.